### PR TITLE
feat: allow core contributors to commit to specified branches

### DIFF
--- a/repo_tools_data_schema/repo_tools_data_schema.py
+++ b/repo_tools_data_schema/repo_tools_data_schema.py
@@ -99,9 +99,10 @@ COMMITTER_SCHEMA = Schema(
                 Optional('orgs'): [valid_org],
                 Optional('repos'): [valid_repo],
                 Optional('champions'): [existing_person],
+                Optional('branches'): [not_empty_string],
             },
-            # You have to specify eithr orgs or repos:
-            one_of_keys("orgs", "repos"),
+            # You have to specify at least one of orgs, repos, or branches:
+            one_of_keys("orgs", "repos", "branches"),
         ),
     ),
 )


### PR DESCRIPTION
Adds `branches` parameter to be used in repo tools data for core committers.

Branches is a set of one or more specified branches that CCs have merge rights to.

Branches can be a specific branch, such as `open-release/maple.1`, or a wildcard such as `open-release*`