### PR TITLE
feat: Be able to configure salesforce CSV encoding.

### DIFF
--- a/repo_tools_data_schema/repo_tools_data_schema.py
+++ b/repo_tools_data_schema/repo_tools_data_schema.py
@@ -245,11 +245,11 @@ def validate_people(filename):
     assert_sorted(people, "Keys in {}".format(filename))
 
 
-def validate_salesforce_export(filename):
+def validate_salesforce_export(filename, encoding="cp1252"):
     """
     Validate that `filename` is a Salesforce export we expect.
     """
-    with open(filename, encoding="cp1252") as fcsv:
+    with open(filename, encoding=encoding) as fcsv:
         reader = csv.DictReader(fcsv)
         # fields are:
         # "First Name","Last Name","Number of Active Ind. CLA Contracts","Title","Account Name","Number of Active Entity CLA Contracts","GitHub Username"


### PR DESCRIPTION
Default to the `cp1252` encoding that used to be hardcoded but
be able to change the encoding.  The latest salesforce CSV data
seems to actually be unicode and has codepoints that are missing
in the Western Europen encoding.

I want to be able to override this with `utf-8` since the new CSV
exports are now UTF-8 encoded rather than `cp1251`.