### PR TITLE
feat: check that named repos actually exist

### DIFF
--- a/repo_tools_data_schema/repo_tools_data_schema.py
+++ b/repo_tools_data_schema/repo_tools_data_schema.py
@@ -6,9 +6,11 @@ import collections
 import csv
 import datetime
 import difflib
+import functools
 import pathlib
 import re
 
+import requests
 import yaml
 from schema import And, Optional, Or, Schema, SchemaError
 from yaml.constructor import ConstructorError
@@ -28,6 +30,12 @@ def valid_email(s):
     )
 
 
+@functools.lru_cache(maxsize=None)
+def success_github_rest(url):
+    resp = requests.get(f"https://api.github.com/{url}")
+    return resp.status_code == 200
+
+
 def valid_org(s):
     """Is this a valid GitHub org?"""
     return isinstance(s, str) and re.match(r"^[^/]+$", s)
@@ -35,7 +43,11 @@ def valid_org(s):
 
 def valid_repo(s):
     """Is this a valid repo?"""
-    return isinstance(s, str) and re.match(r"^[^/]+/[^/]+$", s)
+    return (
+        isinstance(s, str) and
+        re.match(r"^[^/]+/[^/]+$", s) and
+        success_github_rest(f"repos/{s}")
+    )
 
 
 def existing_person(s):

--- a/repo_tools_data_schema/repo_tools_data_schema.py
+++ b/repo_tools_data_schema/repo_tools_data_schema.py
@@ -31,10 +31,14 @@ def valid_email(s):
 
 
 @functools.lru_cache(maxsize=None)
-def success_github_rest(url):
-    resp = requests.get(f"https://api.github.com/{url}")
-    return resp.status_code == 200
-
+def github_repo_exists(full_name):
+    resp = requests.get(f"https://api.github.com/repos/{full_name}")
+    if resp.status_code != 200:
+        raise SchemaError(f"GitHub responded with {resp.status_code} for repo {full_name}")
+    repo_actual_name = resp.json()["full_name"]
+    if repo_actual_name != full_name:
+        raise SchemaError(f"Repo {full_name} is actually at {repo_actual_name}")
+    return True
 
 def valid_org(s):
     """Is this a valid GitHub org?"""
@@ -46,7 +50,7 @@ def valid_repo(s):
     return (
         isinstance(s, str) and
         re.match(r"^[^/]+/[^/]+$", s) and
-        success_github_rest(f"repos/{s}")
+        github_repo_exists(s)
     )
 
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,4 +2,5 @@
 -c constraints.txt
 
 PyYAML
+requests
 schema

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,19 @@
 #
 #    make upgrade
 #
+certifi==2022.6.15
+    # via requests
+charset-normalizer==2.1.1
+    # via requests
 contextlib2==21.6.0
     # via schema
+idna==3.3
+    # via requests
 pyyaml==6.0
+    # via -r requirements/base.in
+requests==2.28.1
     # via -r requirements/base.in
 schema==0.7.5
     # via -r requirements/base.in
+urllib3==1.26.12
+    # via requests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,15 +6,15 @@
 #
 certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.4.1
+coverage==6.4.4
     # via codecov
-distlib==0.3.4
+distlib==0.3.5
     # via virtualenv
-filelock==3.7.1
+filelock==3.8.0
     # via
     #   tox
     #   virtualenv
@@ -30,17 +30,15 @@ py==1.11.0
     # via tox
 pyparsing==3.0.9
     # via packaging
-requests==2.28.0
+requests==2.28.1
     # via codecov
 six==1.16.0
-    # via
-    #   tox
-    #   virtualenv
+    # via tox
 toml==0.10.2
     # via tox
-tox==3.25.0
+tox==3.25.1
     # via -r requirements/ci.in
-urllib3==1.26.9
+urllib3==1.26.12
     # via requests
-virtualenv==20.14.1
+virtualenv==20.16.3
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,24 +4,30 @@
 #
 #    make upgrade
 #
-astroid==2.11.6
+astroid==2.11.7
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/quality.txt
     #   pytest
+build==0.8.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   pip-tools
 certifi==2022.6.15
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   requests
-chardet==4.0.0
+chardet==5.0.0
     # via diff-cover
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   requests
 click==8.1.3
     # via
@@ -45,25 +51,25 @@ contextlib2==21.6.0
     # via
     #   -r requirements/quality.txt
     #   schema
-coverage[toml]==6.4.1
+coverage[toml]==6.4.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
-diff-cover==6.5.0
+diff-cover==6.5.1
     # via -r requirements/dev.in
 dill==0.3.5.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-distlib==0.3.4
+distlib==0.3.5
     # via
     #   -r requirements/ci.txt
     #   virtualenv
 edx-lint==5.2.4
     # via -r requirements/quality.txt
-filelock==3.7.1
+filelock==3.8.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -71,6 +77,7 @@ filelock==3.7.1
 idna==3.3
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   requests
 iniconfig==1.1.1
     # via
@@ -100,18 +107,20 @@ mccabe==0.7.0
 packaging==21.3
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
+    #   build
     #   pytest
     #   tox
-pbr==5.9.0
+pbr==5.10.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pep517==0.12.0
+pep517==0.13.0
     # via
     #   -r requirements/pip-tools.txt
-    #   pip-tools
-pip-tools==6.6.2
+    #   build
+pip-tools==6.8.0
     # via -r requirements/pip-tools.txt
 platformdirs==2.5.2
     # via
@@ -132,11 +141,11 @@ py==1.11.0
     #   -r requirements/quality.txt
     #   pytest
     #   tox
-pycodestyle==2.8.0
+pycodestyle==2.9.1
     # via -r requirements/quality.txt
-pygments==2.12.0
+pygments==2.13.0
     # via diff-cover
-pylint==2.14.3
+pylint==2.14.5
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -159,6 +168,7 @@ pylint-plugin-utils==0.7
 pyparsing==3.0.9
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   packaging
 pytest==7.1.2
@@ -175,9 +185,10 @@ pyyaml==6.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-requests==2.28.0
+requests==2.28.1
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   codecov
 schema==0.7.5
     # via -r requirements/quality.txt
@@ -187,8 +198,7 @@ six==1.16.0
     #   -r requirements/quality.txt
     #   edx-lint
     #   tox
-    #   virtualenv
-stevedore==3.5.0
+stevedore==4.0.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -204,30 +214,32 @@ tomli==2.0.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
+    #   build
     #   coverage
     #   pep517
     #   pylint
     #   pytest
-tomlkit==0.11.0
+tomlkit==0.11.4
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==3.25.0
+tox==3.25.1
     # via
     #   -r requirements/ci.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/dev.in
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-urllib3==1.26.9
+urllib3==1.26.12
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   requests
-virtualenv==20.14.1
+virtualenv==20.16.3
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,29 +6,33 @@
 #
 alabaster==0.7.12
     # via sphinx
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
 babel==2.10.3
     # via sphinx
-bleach==5.0.0
+bleach==5.0.1
     # via readme-renderer
 certifi==2022.6.15
-    # via requests
-charset-normalizer==2.0.12
-    # via requests
+    # via
+    #   -r requirements/test.txt
+    #   requests
+charset-normalizer==2.1.1
+    # via
+    #   -r requirements/test.txt
+    #   requests
 contextlib2==21.6.0
     # via
     #   -r requirements/test.txt
     #   schema
-coverage[toml]==6.4.1
+coverage[toml]==6.4.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-doc8==0.11.2
+doc8==1.0.0
     # via -r requirements/doc.in
-docutils==0.18.1
+docutils==0.19
     # via
     #   doc8
     #   readme-renderer
@@ -37,10 +41,12 @@ docutils==0.18.1
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
 idna==3.3
-    # via requests
-imagesize==1.3.0
+    # via
+    #   -r requirements/test.txt
+    #   requests
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via sphinx
 iniconfig==1.1.1
     # via
@@ -55,7 +61,7 @@ packaging==21.3
     #   -r requirements/test.txt
     #   pytest
     #   sphinx
-pbr==5.9.0
+pbr==5.10.0
     # via stevedore
 pluggy==1.0.0
     # via
@@ -65,7 +71,7 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pygments==2.12.0
+pygments==2.13.0
     # via
     #   doc8
     #   readme-renderer
@@ -80,14 +86,16 @@ pytest==7.1.2
     #   pytest-cov
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-pytz==2022.1
+pytz==2022.2.1
     # via babel
 pyyaml==6.0
     # via -r requirements/test.txt
-readme-renderer==35.0
+readme-renderer==37.0
     # via -r requirements/doc.in
-requests==2.28.0
-    # via sphinx
+requests==2.28.1
+    # via
+    #   -r requirements/test.txt
+    #   sphinx
 restructuredtext-lint==1.4.0
     # via doc8
 schema==0.7.5
@@ -98,7 +106,7 @@ six==1.16.0
     #   edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.0.2
+sphinx==5.1.1
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -114,16 +122,19 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-stevedore==3.5.0
+stevedore==4.0.0
     # via doc8
 tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
+    #   doc8
     #   pytest
-urllib3==1.26.9
-    # via requests
+urllib3==1.26.12
+    # via
+    #   -r requirements/test.txt
+    #   requests
 webencodings==0.5.1
     # via bleach
-zipp==3.8.0
+zipp==3.8.1
     # via importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,14 +4,22 @@
 #
 #    make upgrade
 #
+build==0.8.0
+    # via pip-tools
 click==8.1.3
     # via pip-tools
-pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.2
+packaging==21.3
+    # via build
+pep517==0.13.0
+    # via build
+pip-tools==6.8.0
     # via -r requirements/pip-tools.in
+pyparsing==3.0.9
+    # via packaging
 tomli==2.0.1
-    # via pep517
+    # via
+    #   build
+    #   pep517
 wheel==0.37.1
     # via pip-tools
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1.2
+pip==22.2.2
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,14 +4,22 @@
 #
 #    make upgrade
 #
-astroid==2.11.6
+astroid==2.11.7
     # via
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
+certifi==2022.6.15
+    # via
+    #   -r requirements/test.txt
+    #   requests
+charset-normalizer==2.1.1
+    # via
+    #   -r requirements/test.txt
+    #   requests
 click==8.1.3
     # via
     #   click-log
@@ -25,7 +33,7 @@ contextlib2==21.6.0
     # via
     #   -r requirements/test.txt
     #   schema
-coverage[toml]==6.4.1
+coverage[toml]==6.4.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -33,6 +41,10 @@ dill==0.3.5.1
     # via pylint
 edx-lint==5.2.4
     # via -r requirements/quality.in
+idna==3.3
+    # via
+    #   -r requirements/test.txt
+    #   requests
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -53,7 +65,7 @@ packaging==21.3
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==5.9.0
+pbr==5.10.0
     # via stevedore
 platformdirs==2.5.2
     # via pylint
@@ -65,9 +77,9 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycodestyle==2.8.0
+pycodestyle==2.9.1
     # via -r requirements/quality.in
-pylint==2.14.3
+pylint==2.14.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -97,11 +109,13 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
+requests==2.28.1
+    # via -r requirements/test.txt
 schema==0.7.5
     # via -r requirements/test.txt
 six==1.16.0
     # via edx-lint
-stevedore==3.5.0
+stevedore==4.0.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
@@ -111,12 +125,16 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.0
+tomlkit==0.11.4
     # via pylint
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   astroid
     #   pylint
+urllib3==1.26.12
+    # via
+    #   -r requirements/test.txt
+    #   requests
 wrapt==1.14.1
     # via astroid
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,14 +4,26 @@
 #
 #    make upgrade
 #
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
+certifi==2022.6.15
+    # via
+    #   -r requirements/base.txt
+    #   requests
+charset-normalizer==2.1.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 contextlib2==21.6.0
     # via
     #   -r requirements/base.txt
     #   schema
-coverage[toml]==6.4.1
+coverage[toml]==6.4.4
     # via pytest-cov
+idna==3.3
+    # via
+    #   -r requirements/base.txt
+    #   requests
 iniconfig==1.1.1
     # via pytest
 packaging==21.3
@@ -28,9 +40,15 @@ pytest-cov==3.0.0
     # via -r requirements/test.in
 pyyaml==6.0
     # via -r requirements/base.txt
+requests==2.28.1
+    # via -r requirements/base.txt
 schema==0.7.5
     # via -r requirements/base.txt
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
+urllib3==1.26.12
+    # via
+    #   -r requirements/base.txt
+    #   requests


### PR DESCRIPTION
When naming repos in the `committer` clauses, it's easy to have incorrect references.  Now we use requests against the GitHub REST API to check that they actually exist and are correctly named.