### PR TITLE
test!: Don't validate salesforce orgs against orgs.yml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,16 @@ Change Log
 
    This project adheres to Semantic Versioning (https://semver.org/).
 
+2022-09-22
+~~~~~~~~~~
+
+Changed
+=======
+
+* Don't validate orgs using orgs.yaml in the saleseforce export csv.
+
+
+
 2020-08-07
 ~~~~~~~~~~
 

--- a/repo_tools_data_schema/repo_tools_data_schema.py
+++ b/repo_tools_data_schema/repo_tools_data_schema.py
@@ -274,10 +274,6 @@ def validate_salesforce_export(filename, encoding="cp1252"):
             if acct == "Opfocus Test":
                 # A bogus entry made by the vendor. skip it.
                 continue
-            # "Individual Contributors" and "Household Accounts" are both Salesforce artifacts.
-            # In both cases, these records represent unaffiliated individual contributors.
-            acct_valid = (acct in ALL_ORGS or acct == "Individual Contributors" or acct.endswith(" Household"))
-            assert acct_valid, f"Account Name is not a valid org: {acct}"
             username = row["GitHub Username"]
             assert github_username(username), f"GitHub Username is not valid: {username}"
 


### PR DESCRIPTION
BREAKING CHANGE: We no longer test that the "Account Name" for the CSV has a valid
entry in the orgs.yaml file in the same directory.  This doesn't make sense because
salesforce is now the source of truth so also needing we can trust it to have valid
orgs. And if it doesn't that should be fixed in the salesforce process and not here.
