### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,7 @@ How To Contribute
 -----------------
 
 Contributions are very welcome.
-Please read `How To Contribute <https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details.
-Even though they were written with ``edx-platform`` in mind, the guidelines
+Please read `How To Contribute <https://github.com/openedx/.github/blob/master/CONTRIBUTING.md>`_ for details.
 should be followed for all Open edX projects.
 
 Reporting Security Issues


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide.
