### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,20 +4,12 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.0.1
-    # via requests
-coverage==7.2.1
-    # via codecov
 distlib==0.3.6
     # via virtualenv
 filelock==3.9.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
 packaging==23.0
     # via tox
 platformdirs==3.0.0
@@ -26,8 +18,6 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -36,7 +26,5 @@ tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/ci.in
-urllib3==1.26.14
-    # via requests
 virtualenv==20.19.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,14 +21,12 @@ build==0.10.0
     #   pip-tools
 certifi==2022.12.7
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 chardet==5.1.0
     # via diff-cover
 charset-normalizer==3.0.1
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 click==8.1.3
@@ -53,9 +51,7 @@ contextlib2==21.6.0
     #   schema
 coverage[toml]==7.2.1
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
 diff-cover==7.5.0
     # via -r requirements/dev.in
@@ -80,7 +76,6 @@ filelock==3.9.0
     #   virtualenv
 idna==3.4
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 iniconfig==2.0.0
@@ -182,10 +177,7 @@ pyyaml==6.0
     #   -r requirements/quality.txt
     #   code-annotations
 requests==2.28.2
-    # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
-    #   codecov
+    # via -r requirements/quality.txt
 schema==0.7.5
     # via -r requirements/quality.txt
 six==1.16.0
@@ -231,7 +223,6 @@ typing-extensions==4.5.0
     #   pylint
 urllib3==1.26.14
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 virtualenv==20.19.0

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -4,6 +4,6 @@
 -r test.txt               # Core and testing dependencies for this package
 
 doc8                      # reStructuredText style checker
-edx_sphinx_theme          # edX theme for Sphinx output
+sphinx-book-theme         # Common theme for all Open edX projects
 readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 attrs==22.2.0
@@ -11,9 +13,13 @@ attrs==22.2.0
     #   -r requirements/test.txt
     #   pytest
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 backoff==2.2.1
     # via -r requirements/test.txt
+beautifulsoup4==4.12.2
+    # via pydata-sphinx-theme
 bleach==6.0.0
     # via readme-renderer
 certifi==2022.12.7
@@ -37,11 +43,10 @@ doc8==1.1.1
 docutils==0.19
     # via
     #   doc8
+    #   pydata-sphinx-theme
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
 exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
@@ -65,6 +70,7 @@ markupsafe==2.1.2
 packaging==23.0
     # via
     #   -r requirements/test.txt
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
 pbr==5.11.1
@@ -73,9 +79,13 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.14.0
     # via
+    #   accessible-pygments
     #   doc8
+    #   pydata-sphinx-theme
     #   readme-renderer
     #   sphinx
 pytest==7.2.1
@@ -99,16 +109,19 @@ restructuredtext-lint==1.4.0
 schema==0.7.5
     # via -r requirements/test.txt
 six==1.16.0
-    # via
-    #   bleach
-    #   edx-sphinx-theme
+    # via bleach
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.4.1
+    # via beautifulsoup4
 sphinx==5.3.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/doc.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -129,6 +142,8 @@ tomli==2.0.1
     #   coverage
     #   doc8
     #   pytest
+typing-extensions==4.5.0
+    # via pydata-sphinx-theme
 urllib3==1.26.14
     # via
     #   -r requirements/test.txt

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,9 +4,11 @@
 #
 #    make upgrade
 #
+wheel==0.38.4
+    # via -r requirements/pip.in
+
+# The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
 setuptools==67.4.0
-    # via -r requirements/pip.in
-wheel==0.38.4
     # via -r requirements/pip.in


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme.
This removes references to the deprecated theme, replaces them with the new
standard theme for the platform, and updates the theme configuraiton to use the
new theme.


**Testing instructions:**
- Run `make docs` or `make html` in the docs directory and see that the docs are generated properly and use the sphinx-book-theme

See https://github.com/openedx/public-engineering/issues/200