### PR TITLE
feat: Make it valid for ORGS, LABELS, and PEOPLE to be empty

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,14 @@ Change Log
 
    This project adheres to Semantic Versioning (https://semver.org/).
 
+
+2023-05-30
+~~~~~~~~~~
+
+* Make it valid for ORGS, LABELS, and PEOPLE to be empty. This was prompted
+  because we actually want LABELS to be empty as an intermediate step towards
+  removing label creation from openedx-webhooks.
+
 2023-03-02
 ~~~~~~~~~~
 

--- a/repo_tools_data_schema/__init__.py
+++ b/repo_tools_data_schema/__init__.py
@@ -2,6 +2,6 @@
 Schema for repo-tools-data.
 """
 
-__version__ = '1.0'
+__version__ = '1.1'
 
 from .repo_tools_data_schema import validate_labels, validate_orgs, validate_people, validate_salesforce_export

--- a/repo_tools_data_schema/repo_tools_data_schema.py
+++ b/repo_tools_data_schema/repo_tools_data_schema.py
@@ -140,52 +140,58 @@ COMMITTER_SCHEMA = Schema(
 )
 
 PEOPLE_SCHEMA = Schema(
-    {
-        And(github_username, not_data_key): And(
-            {
-                'name': not_empty_string,
-                'email': valid_email,
-                'agreement': valid_agreement,
-                Optional('institution'): not_empty_string,
-                Optional('is_robot'): True,
-                Optional('jira'): not_empty_string,
-                Optional('comments'): [str],
-                Optional('other_emails'): [valid_email],
-                Optional('before'): {
-                    datetime.date: And(
-                        {
-                            Optional('agreement'): valid_agreement,
-                            Optional('institution'): not_empty_string,
-                            Optional('comments'): [str],
-                            Optional('committer'): COMMITTER_SCHEMA,
-                        },
-                        check_institution,
-                    ),
+    Or(
+        {
+            And(github_username, not_data_key): And(
+                {
+                    'name': not_empty_string,
+                    'email': valid_email,
+                    'agreement': valid_agreement,
+                    Optional('institution'): not_empty_string,
+                    Optional('is_robot'): True,
+                    Optional('jira'): not_empty_string,
+                    Optional('comments'): [str],
+                    Optional('other_emails'): [valid_email],
+                    Optional('before'): {
+                        datetime.date: And(
+                            {
+                                Optional('agreement'): valid_agreement,
+                                Optional('institution'): not_empty_string,
+                                Optional('comments'): [str],
+                                Optional('committer'): COMMITTER_SCHEMA,
+                            },
+                            check_institution,
+                        ),
+                    },
+                    Optional('beta'): bool,
+                    Optional('contractor'): bool,
+                    Optional('committer'): COMMITTER_SCHEMA,
+                    Optional('email_ok'): bool,
                 },
-                Optional('beta'): bool,
-                Optional('contractor'): bool,
-                Optional('committer'): COMMITTER_SCHEMA,
-                Optional('email_ok'): bool,
-            },
-            check_institution,
-        ),
-    }
+                check_institution,
+            ),
+        },
+        {},
+    ),
 )
 
 ORGS_SCHEMA = Schema(
-    {
-        str: {
-            Optional("name"): not_empty_string,
-            "agreement": Or("institution", "none"),
-            Optional("contractor"): bool,
-            Optional("committer"): bool,
-            Optional("internal-ghorgs"): [str],
-            Optional(Or("contact", "contact1", "contact2")): {
-                "name": not_empty_string,
-                "email": valid_email,
+    Or(
+        {
+            str: {
+                Optional("name"): not_empty_string,
+                "agreement": Or("institution", "none"),
+                Optional("contractor"): bool,
+                Optional("committer"): bool,
+                Optional("internal-ghorgs"): [str],
+                Optional(Or("contact", "contact1", "contact2")): {
+                    "name": not_empty_string,
+                    "email": valid_email,
+                },
             },
         },
-    }
+        {},
+    )
 )
 
 
@@ -194,19 +200,22 @@ def color(s):
 
 
 LABELS_SCHEMA = Schema(
-    {
-        str: Or(
-            # A label we don't want:
-            {
-                "delete": True,
-            },
-            # A label we want:
-            {
-                "color": color,
-                Optional("description"): str,
-            },
-        ),
-    },
+    Or(
+        {
+            str: Or(
+                # A label we don't want:
+                {
+                    "delete": True,
+                },
+                # A label we want:
+                {
+                    "color": color,
+                    Optional("description"): str,
+                },
+            ),
+        },
+        {},
+    ),
 )
 
 


### PR DESCRIPTION
This was prompted because we actually want LABELS to be empty as an intermediate step towards removing label creation from openedx-webhooks.

Per the docs on https://pypi.org/project/schema/ (scroll down to "Dictionaries"), schema validation will fail on empty dictionaries unless you specifically make the schema `Or(<dict>, {})`. 

The only changes in this PR are wrapping each dict schema in `Or(..., {})`. I tested locally that this fixes https://github.com/openedx/openedx-webhooks-data/pull/191

Part of https://github.com/openedx/openedx-webhooks/issues/218

