### PR TITLE
feat!: remove `validate_labels`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,15 @@ Change Log
    This project adheres to Semantic Versioning (https://semver.org/).
 
 
-2023-05-30
-~~~~~~~~~~
+2.0 (2023-06-20)
+~~~~~~~~~~~~~~~~
+
+* Delete ``validate_labels``, since ``labels.yaml`` is not longer used by
+  openedx-webhooks.
+  
+
+1.1 (2023-05-30)
+~~~~~~~~~~~~~~~~
 
 * Make it valid for ORGS, LABELS, and PEOPLE to be empty. This was prompted
   because we actually want LABELS to be empty as an intermediate step towards

--- a/repo_tools_data_schema/__init__.py
+++ b/repo_tools_data_schema/__init__.py
@@ -2,6 +2,6 @@
 Schema for repo-tools-data.
 """
 
-__version__ = '1.1'
+__version__ = '2.0'
 
-from .repo_tools_data_schema import validate_labels, validate_orgs, validate_people, validate_salesforce_export
+from .repo_tools_data_schema import validate_orgs, validate_people, validate_salesforce_export

--- a/repo_tools_data_schema/repo_tools_data_schema.py
+++ b/repo_tools_data_schema/repo_tools_data_schema.py
@@ -199,26 +199,6 @@ def color(s):
     return re.match(r"^[a-fA-F0-9]{6}$", s)
 
 
-LABELS_SCHEMA = Schema(
-    Or(
-        {
-            str: Or(
-                # A label we don't want:
-                {
-                    "delete": True,
-                },
-                # A label we want:
-                {
-                    "color": color,
-                    Optional("description"): str,
-                },
-            ),
-        },
-        {},
-    ),
-)
-
-
 # Prevent duplicate keys in YAML.
 # Adapted from https://gist.github.com/pypt/94d747fe5180851196eb
 # from https://bitbucket.org/xi/pyyaml/issues/9/ignore-duplicate-keys-and-send-warning-or
@@ -242,14 +222,6 @@ yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, 
 
 
 # The public functions.
-
-def validate_labels(filename):
-    """
-    Validate that `filename` conforms to our labels.yaml schema.
-    """
-    with open(filename) as f:
-        labels = yaml.safe_load(f)
-    LABELS_SCHEMA.validate(labels)
 
 
 def validate_orgs(filename):


### PR DESCRIPTION
``labels.yaml`` is not longer used by openedx-webhooks, since https://github.com/openedx/openedx-webhooks/pull/245

Part of: https://github.com/openedx/openedx-webhooks/issues/218