### PR TITLE
feat!: we no longer validate old-style labels.yaml files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,12 @@ Change Log
    This project adheres to Semantic Versioning (https://semver.org/).
 
 
+2023-07-25
+~~~~~~~~~~
+
+* Removed validation of labels.yaml files.  The OSPR bot no longer reads
+  labels.yaml, so that file will be deleted.
+
 2023-05-30
 ~~~~~~~~~~
 

--- a/repo_tools_data_schema/__init__.py
+++ b/repo_tools_data_schema/__init__.py
@@ -4,4 +4,4 @@ Schema for repo-tools-data.
 
 __version__ = '1.1'
 
-from .repo_tools_data_schema import validate_labels, validate_orgs, validate_people, validate_salesforce_export
+from .repo_tools_data_schema import validate_orgs, validate_people, validate_salesforce_export

--- a/repo_tools_data_schema/repo_tools_data_schema.py
+++ b/repo_tools_data_schema/repo_tools_data_schema.py
@@ -195,30 +195,6 @@ ORGS_SCHEMA = Schema(
 )
 
 
-def color(s):
-    return re.match(r"^[a-fA-F0-9]{6}$", s)
-
-
-LABELS_SCHEMA = Schema(
-    Or(
-        {
-            str: Or(
-                # A label we don't want:
-                {
-                    "delete": True,
-                },
-                # A label we want:
-                {
-                    "color": color,
-                    Optional("description"): str,
-                },
-            ),
-        },
-        {},
-    ),
-)
-
-
 # Prevent duplicate keys in YAML.
 # Adapted from https://gist.github.com/pypt/94d747fe5180851196eb
 # from https://bitbucket.org/xi/pyyaml/issues/9/ignore-duplicate-keys-and-send-warning-or
@@ -242,15 +218,6 @@ yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, 
 
 
 # The public functions.
-
-def validate_labels(filename):
-    """
-    Validate that `filename` conforms to our labels.yaml schema.
-    """
-    with open(filename) as f:
-        labels = yaml.safe_load(f)
-    LABELS_SCHEMA.validate(labels)
-
 
 def validate_orgs(filename):
     """


### PR DESCRIPTION
Now that the OSPR bot doesn't use labels.yaml, no one needs validate_labels any more.

repo-tools has a labels.yaml file, but it uses a slightly different schema, and is unvalidated.  Perhaps we should be adapting this code to that file instead of deleting it?