### PR TITLE
fix: remove tox-battery from requirements

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,27 +4,35 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 distlib==0.3.7
     # via virtualenv
-filelock==3.12.2
+filelock==3.13.1
     # via
     #   tox
     #   virtualenv
-packaging==23.1
+packaging==23.2
+    # via
+    #   pyproject-api
+    #   tox
+platformdirs==4.1.0
+    # via
+    #   tox
+    #   virtualenv
+pluggy==1.3.0
     # via tox
-platformdirs==3.10.0
-    # via virtualenv
-pluggy==1.2.0
-    # via tox
-py==1.11.0
-    # via tox
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
-    # via tox
-tox==3.28.0
     # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/ci.in
-virtualenv==20.24.2
+    #   pyproject-api
+    #   tox
+tox==4.11.4
+    # via -r requirements/ci.in
+virtualenv==20.25.0
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -21,7 +21,3 @@ elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
-
-# tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
-# Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
-tox<4.0.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -6,4 +6,3 @@
 -r ci.txt             # tox and related dependencies
 
 diff-cover                # Changeset diff test coverage
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,18 +4,25 @@
 #
 #    make upgrade
 #
-astroid==2.15.6
+astroid==3.0.1
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-build==0.10.0
+build==1.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
+cachetools==5.3.2
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 chardet==5.2.0
-    # via diff-cover
-click==8.1.6
+    # via
+    #   -r requirements/ci.txt
+    #   diff-cover
+    #   tox
+click==8.1.7
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -31,15 +38,20 @@ code-annotations==1.5.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
+colorama==0.4.6
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 contextlib2==21.6.0
     # via
     #   -r requirements/quality.txt
     #   schema
-coverage[toml]==7.2.7
+coverage[toml]==7.3.2
     # via
     #   -r requirements/quality.txt
+    #   coverage
     #   pytest-cov
-diff-cover==7.7.0
+diff-cover==8.0.1
     # via -r requirements/dev.in
 dill==0.3.7
     # via
@@ -49,17 +61,21 @@ distlib==0.3.7
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via -r requirements/quality.txt
-exceptiongroup==1.1.2
+exceptiongroup==1.2.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-filelock==3.12.2
+filelock==3.13.1
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
+importlib-metadata==7.0.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   build
 iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
@@ -73,10 +89,6 @@ jinja2==3.1.2
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
-lazy-object-proxy==1.9.0
-    # via
-    #   -r requirements/quality.txt
-    #   astroid
 markupsafe==2.1.3
     # via
     #   -r requirements/quality.txt
@@ -85,42 +97,40 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-packaging==23.1
+packaging==23.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   build
+    #   pyproject-api
     #   pytest
     #   tox
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
 pip-tools==7.3.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.10.0
+platformdirs==4.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pylint
+    #   tox
     #   virtualenv
-pluggy==1.2.0
+pluggy==1.3.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   diff-cover
     #   pytest
     #   tox
-py==1.11.0
-    # via
-    #   -r requirements/ci.txt
-    #   tox
-pycodestyle==2.11.0
+pycodestyle==2.11.1
     # via -r requirements/quality.txt
-pygments==2.16.1
+pygments==2.17.2
     # via diff-cover
-pylint==2.17.5
+pylint==3.0.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -131,7 +141,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.5.3
+pylint-django==2.5.5
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -140,11 +150,15 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.4.0
+pytest==7.4.3
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -162,10 +176,8 @@ schema==0.7.5
     # via -r requirements/quality.txt
 six==1.16.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-lint
-    #   tox
 stevedore==5.1.0
     # via
     #   -r requirements/quality.txt
@@ -183,37 +195,33 @@ tomli==2.0.1
     #   coverage
     #   pip-tools
     #   pylint
+    #   pyproject-api
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==3.28.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/ci.txt
-    #   tox-battery
-tox-battery==0.6.1
-    # via -r requirements/dev.in
-typing-extensions==4.7.1
+tox==4.11.4
+    # via -r requirements/ci.txt
+typing-extensions==4.8.0
     # via
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-virtualenv==20.24.2
+virtualenv==20.25.0
     # via
     #   -r requirements/ci.txt
     #   tox
-wheel==0.41.1
+wheel==0.42.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-wrapt==1.15.0
+zipp==3.17.0
     # via
-    #   -r requirements/quality.txt
-    #   astroid
+    #   -r requirements/pip-tools.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,25 +8,24 @@ accessible-pygments==0.0.4
     # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
-babel==2.12.1
+babel==2.13.1
     # via
     #   pydata-sphinx-theme
     #   sphinx
 beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
-bleach==6.0.0
-    # via readme-renderer
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
 contextlib2==21.6.0
     # via
     #   -r requirements/test.txt
     #   schema
-coverage[toml]==7.2.7
+coverage[toml]==7.3.2
     # via
     #   -r requirements/test.txt
+    #   coverage
     #   pytest-cov
 doc8==1.1.1
     # via -r requirements/doc.in
@@ -37,15 +36,15 @@ docutils==0.19
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-exceptiongroup==1.1.2
+exceptiongroup==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
-idna==3.4
+idna==3.6
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via sphinx
 iniconfig==2.0.0
     # via
@@ -55,38 +54,40 @@ jinja2==3.1.2
     # via sphinx
 markupsafe==2.1.3
     # via jinja2
-packaging==23.1
+nh3==0.2.15
+    # via readme-renderer
+packaging==23.2
     # via
     #   -r requirements/test.txt
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
-pluggy==1.2.0
+pluggy==1.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pydata-sphinx-theme==0.13.3
+pydata-sphinx-theme==0.14.4
     # via sphinx-book-theme
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   accessible-pygments
     #   doc8
     #   pydata-sphinx-theme
     #   readme-renderer
     #   sphinx
-pytest==7.4.0
+pytest==7.4.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 pytest-cov==4.1.0
     # via -r requirements/test.txt
-pytz==2023.3
+pytz==2023.3.post1
     # via babel
 pyyaml==6.0.1
     # via -r requirements/test.txt
-readme-renderer==40.0
+readme-renderer==42.0
     # via -r requirements/doc.in
 requests==2.31.0
     # via sphinx
@@ -94,11 +95,9 @@ restructuredtext-lint==1.4.0
     # via doc8
 schema==0.7.5
     # via -r requirements/test.txt
-six==1.16.0
-    # via bleach
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.4.1
+soupsieve==2.5
     # via beautifulsoup4
 sphinx==6.2.1
     # via
@@ -127,11 +126,9 @@ tomli==2.0.1
     #   coverage
     #   doc8
     #   pytest
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via pydata-sphinx-theme
-urllib3==2.0.4
+urllib3==2.1.0
     # via requests
-webencodings==0.5.1
-    # via bleach
-zipp==3.16.2
+zipp==3.17.0
     # via importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,11 +4,13 @@
 #
 #    make upgrade
 #
-build==0.10.0
+build==1.0.3
     # via pip-tools
-click==8.1.6
+click==8.1.7
     # via pip-tools
-packaging==23.1
+importlib-metadata==7.0.0
+    # via build
+packaging==23.2
     # via build
 pip-tools==7.3.0
     # via -r requirements/pip-tools.in
@@ -19,8 +21,10 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.1
+wheel==0.42.0
     # via pip-tools
+zipp==3.17.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.41.1
+wheel==0.42.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.2.1
+pip==23.3.1
     # via -r requirements/pip.in
-setuptools==68.0.0
+setuptools==69.0.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-astroid==2.15.6
+astroid==3.0.1
     # via
     #   pylint
     #   pylint-celery
-click==8.1.6
+click==8.1.7
     # via
     #   click-log
     #   code-annotations
@@ -21,15 +21,16 @@ contextlib2==21.6.0
     # via
     #   -r requirements/test.txt
     #   schema
-coverage[toml]==7.2.7
+coverage[toml]==7.3.2
     # via
     #   -r requirements/test.txt
+    #   coverage
     #   pytest-cov
 dill==0.3.7
     # via pylint
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via -r requirements/quality.in
-exceptiongroup==1.1.2
+exceptiongroup==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -43,27 +44,25 @@ isort==5.12.0
     #   pylint
 jinja2==3.1.2
     # via code-annotations
-lazy-object-proxy==1.9.0
-    # via astroid
 markupsafe==2.1.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
-packaging==23.1
+packaging==23.2
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
-platformdirs==3.10.0
+platformdirs==4.1.0
     # via pylint
-pluggy==1.2.0
+pluggy==1.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycodestyle==2.11.0
+pycodestyle==2.11.1
     # via -r requirements/quality.in
-pylint==2.17.5
+pylint==3.0.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -71,13 +70,13 @@ pylint==2.17.5
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.3
+pylint-django==2.5.5
     # via edx-lint
 pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
-pytest==7.4.0
+pytest==7.4.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -103,11 +102,9 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   astroid
     #   pylint
-wrapt==1.15.0
-    # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,17 +8,19 @@ contextlib2==21.6.0
     # via
     #   -r requirements/base.txt
     #   schema
-coverage[toml]==7.2.7
-    # via pytest-cov
-exceptiongroup==1.1.2
+coverage[toml]==7.3.2
+    # via
+    #   coverage
+    #   pytest-cov
+exceptiongroup==1.2.0
     # via pytest
 iniconfig==2.0.0
     # via pytest
-packaging==23.1
+packaging==23.2
     # via pytest
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
-pytest==7.4.0
+pytest==7.4.3
     # via pytest-cov
 pytest-cov==4.1.0
     # via -r requirements/test.in


### PR DESCRIPTION
## Description
- Removed `tox-battery` from requirements and updated `tox` to `v4`.